### PR TITLE
chores: remove redundant plugin

### DIFF
--- a/lua/theprimeagen/lazy/init.lua
+++ b/lua/theprimeagen/lazy/init.lua
@@ -7,6 +7,5 @@ return {
 
     "github/copilot.vim",
     "eandrju/cellular-automaton.nvim",
-    "gpanders/editorconfig.nvim",
 }
 


### PR DESCRIPTION
Neovim 0.9 has EditorConfig integration builtin, so this plugin is no longer necessary. 

 references: 
https://github.com/gpanders/editorconfig.nvim#project-status 
https://neovim.io/doc/user/editorconfig.html